### PR TITLE
feat:(logging): replace log with structured logging using slog

### DIFF
--- a/internal/collector/storagebox.go
+++ b/internal/collector/storagebox.go
@@ -2,7 +2,7 @@ package collector
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"strconv"
 	"time"
 
@@ -171,7 +171,10 @@ func (c *StorageBoxCollector) Collect(ch chan<- prometheus.Metric) {
 
 	boxes, err := c.client.ListStorageBoxes(ctx)
 	if err != nil {
-		log.Printf("Error fetching storage boxes: %v", err)
+		slog.Error("Failed to fetch storage boxes from Hetzner API",
+			"error", err,
+			"timeout", "30s",
+		)
 		c.scrapeErrors.Inc()
 		c.scrapeErrors.Collect(ch)
 		return


### PR DESCRIPTION
- Updated storagebox.go to use slog for error logging
- Initialized structured logger in main.go
- Replaced log.Fatalf with slog.Error and os.Exit
- Added parseLogLevel function for log level conversion
- Updated various log statements to include context information