### PR TITLE
fix(deps): update go to v1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crstian19/prometheus-storagebox-exporter
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/prometheus/client_golang v1.23.2


### PR DESCRIPTION
## Summary

- Update `go.mod` minimum Go version from `1.26.1` to `1.26.2`, matching the Dockerfile and CI workflow already updated in #60 and #61.