### PR TITLE
fix(release): document releasable commit types

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -292,6 +292,7 @@ Triggers: Git tag (v*)
 - **MAJOR:** Breaking changes (API changes, removed metrics)
 - **MINOR:** New features (new metrics, new flags)
 - **PATCH:** Bug fixes, documentation updates
+- **Release trigger note:** Releaser Pleaser ignores non-releasable conventional commit types such as `chore:`. Dependency or CI changes that should produce a patch release must be merged under a releasable type such as `fix:`.
 
 ## Docker Strategy
 


### PR DESCRIPTION
This documents a repo-specific release behavior we just hit: dependency and CI updates merged as `chore:` do not trigger Releaser Pleaser, so release-worthy maintenance changes should use a releasable conventional commit type such as `fix:`.\n\nThis also gives Releaser Pleaser one releasable commit so it can open the next automated release PR.