### PR TITLE
Metrics hygiene, ko-based images, and dev tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Run golangci-lint
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Download dependencies
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Build binary
@@ -108,7 +108,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,13 @@ jobs:
           go-version: '1.26.4'
           cache: true
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -120,50 +127,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: crstian19
-
-  docker:
-    name: Build and Push Docker Images
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [release]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/prometheus-storagebox-exporter
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
-
-      - name: Build and push multi-arch Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
-            GIT_COMMIT=${{ github.sha }}
-            BUILD_DATE=${{ github.event.head_commit.timestamp }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,21 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  packages: write
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  GO_VERSION: "1.26.5"
 
 jobs:
-  lint:
-    name: Lint
+  verify:
+    name: Verify Sources
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -25,7 +32,38 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Verify module dependencies
+        run: |
+          go mod download
+          go mod verify
+
+      - name: Ensure go.mod and go.sum are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Check gofmt
+        run: test -z "$(gofmt -l .)"
+
+      - name: Run go vet
+        run: go vet ./...
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
           cache: true
 
       - name: Run golangci-lint
@@ -37,6 +75,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -44,7 +84,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: ${{ env.GO_VERSION }}
           cache: true
 
       - name: Download dependencies
@@ -60,45 +100,38 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-  build:
-    name: Build
+  assets:
+    name: Validate Runtime Assets
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux, darwin, windows]
-        goarch: [amd64, arm64]
-        exclude:
-          - goos: windows
-            goarch: arm64
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.26.5'
-          cache: true
+      - name: Validate Grafana dashboard JSON
+        run: jq -e '.title and .panels' grafana-provisioning/dashboards/grafana-dashboard.json > /dev/null
 
-      - name: Build binary
+      - name: Validate Docker Compose files
         env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 0
+          HETZNER_TOKEN: test-token
         run: |
-          go build -v -ldflags="-w -s" -o dist/prometheus-storagebox-exporter-${{ matrix.goos }}-${{ matrix.goarch }} .
+          docker compose -f docker-compose.yml config -q
+          docker compose -f docker-compose.dev.yml config -q
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: prometheus-storagebox-exporter-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: dist/prometheus-storagebox-exporter-${{ matrix.goos }}-${{ matrix.goarch }}
+      - name: Validate Prometheus configuration
+        run: |
+          docker run --rm \
+            -v "$PWD/prometheus.yml:/etc/prometheus/prometheus.yml:ro" \
+            --entrypoint promtool \
+            prom/prometheus:latest \
+            check config /etc/prometheus/prometheus.yml
 
-  release:
-    name: Release
+  release-check:
+    name: Validate Release Config
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [lint, test]
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -108,7 +141,106 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Validate GoReleaser configuration
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: check
+        env:
+          GITHUB_REPOSITORY_OWNER: crstian19
+
+  build:
+    name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: linux
+            goarch: arm
+            goarm: "7"
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Cross-compile binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          GOARM: ${{ matrix.goarm }}
+          CGO_ENABLED: 0
+        run: |
+          extension=""
+          if [ "${GOOS}" = "windows" ]; then
+            extension=".exe"
+          fi
+          suffix="${GOOS}-${GOARCH}"
+          if [ -n "${GOARM}" ]; then
+            suffix="${suffix}v${GOARM}"
+          fi
+          go build -trimpath -ldflags="-w -s" -o "dist/prometheus-storagebox-exporter-${suffix}${extension}" .
+
+  docker-smoke:
+    name: Docker Smoke Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg VERSION=ci \
+            --build-arg GIT_COMMIT="${GITHUB_SHA}" \
+            --build-arg BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -t prometheus-storagebox-exporter:ci \
+            .
+
+      - name: Smoke test image
+        run: docker run --rm prometheus-storagebox-exporter:ci --version
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [verify, lint, test, assets, release-check, build, docker-smoke]
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
           cache: true
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "25 4 * * 1"
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,26 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Review Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,6 @@ jobs:
           go-version: '1.26.4'
           cache: true
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/releaser-pleaser.yml
+++ b/.github/workflows/releaser-pleaser.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Releaser Pleaser
-        uses: apricote/releaser-pleaser@v0.8.0
+        uses: apricote/releaser-pleaser@v0.9.0
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           extra-files: |

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ Claude.md
 
 # CommitSage configuration (development-only)
 .commitsage
+
+# lefthook personal overrides (not shared with the team)
+lefthook-local.yml

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,6 +54,25 @@ archives:
       - DESIGN.md
       - grafana-provisioning/dashboards/grafana-dashboard.json
 
+# Container images built with ko (no Dockerfile): static Chainguard base,
+# multi-arch, SBOM. Replaces the previous docker buildx + QEMU job.
+kos:
+  - id: sb-image
+    build: prometheus-storagebox-exporter
+    base_image: cgr.dev/chainguard/static
+    repositories:
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/prometheus-storagebox-exporter
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    tags:
+      - "{{ .Version }}"
+      - "{{ if not .Prerelease }}latest{{ end }}"
+    bare: true
+    sbom: spdx
+    creation_time: "{{ .CommitTimestamp }}"
+    ko_data_creation_time: "{{ .CommitTimestamp }}"
+
 checksum:
   name_template: 'checksums.txt'
 

--- a/.lefthook/commit-msg/validate-conventional.sh
+++ b/.lefthook/commit-msg/validate-conventional.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Validate the commit message against Conventional Commits.
+# releaser-pleaser relies on these types to compute releases, so keep them honest.
+# No Node dependency: pure bash, matching the vault's lefthook note.
+set -euo pipefail
+
+msg="$(head -1 "$1")"
+pattern='^(feat|fix|docs|style|refactor|test|chore|perf|build|ci|revert)(\(.+\))?!?: .+'
+
+# Allow merge commits through untouched.
+if [[ "$msg" =~ ^Merge ]]; then
+  exit 0
+fi
+
+if ! [[ "$msg" =~ $pattern ]]; then
+  echo "✗ Commit message does not follow Conventional Commits: '$msg'"
+  echo "  Valid examples: 'feat: add ZFS access metric', 'fix(collector): omit metrics on API error'"
+  exit 1
+fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# NOTE: Release images are built with ko via goreleaser (see .goreleaser.yml).
+# This Dockerfile is kept only for local `docker build` and docker-compose.
+#
 # Stage 1: Build
 FROM golang:1.26.4-alpine AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # This Dockerfile is kept only for local `docker build` and docker-compose.
 #
 # Stage 1: Build
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 RUN apk add --no-cache ca-certificates tzdata
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test lint clean run docker-build docker-run install
+.PHONY: help setup build test lint clean run docker-build docker-run install
 
 # Variables
 BINARY_NAME=prometheus-storagebox-exporter
@@ -13,6 +13,12 @@ help: ## Show this help message
 	@echo ""
 	@echo "Available targets:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
+
+setup: ## Install git hooks and download dependencies (run once per clone)
+	@echo "Setting up development environment..."
+	@lefthook install
+	@go mod download
+	@echo "Setup complete!"
 
 build: ## Build the binary
 	@echo "Building $(BINARY_NAME) $(VERSION)..."

--- a/README.md
+++ b/README.md
@@ -251,9 +251,10 @@ The exporter exposes 15+ metrics organized in 4 categories:
 
 | Metric | Type | Description |
 |--------|------|-------------|
+| `storagebox_exporter_up` | Gauge | Whether the last scrape of the Hetzner API succeeded (1=healthy, 0=unhealthy). On failure, storage box metrics are omitted |
+| `storagebox_exporter_build_info` | Gauge | Build information (value always 1). Labels: version, revision, goversion, build_date |
 | `storagebox_exporter_scrape_duration_seconds` | Gauge | Duration of the scrape in seconds |
 | `storagebox_exporter_scrape_errors_total` | Counter | Total number of scrape errors |
-| `storagebox_exporter_up` | Gauge | Exporter health status (1=healthy, 0=unhealthy) |
 | `storagebox_exporter_cache_hits_total` | Counter | Total number of cache hits (0 when cache disabled) |
 | `storagebox_exporter_cache_misses_total` | Counter | Total number of cache misses (increments every scrape when cache disabled) |
 
@@ -548,20 +549,32 @@ spec:
 
 ## 🏗️ Development
 
+### Setup
+
+The toolchain is pinned with [mise](https://mise.jdx.dev) (`mise.toml`) and git hooks are
+managed with [lefthook](https://github.com/evilmartians/lefthook). One-time setup per clone:
+
+```bash
+mise install     # installs Go + golangci-lint + goreleaser + ko + lefthook + gitleaks
+make setup       # installs the git hooks (lefthook install) and downloads deps
+```
+
+Hooks: `pre-commit` runs gitleaks + `gofmt` + incremental lint; `pre-push` runs the full
+`make test` and `make lint` — the same checks as CI, so failures surface locally first.
+
 ### Building
 
 ```bash
 # Build binary
-go build -o prometheus-storagebox-exporter .
+make build            # or: go build -o prometheus-storagebox-exporter .
 
-# Build Docker image
-docker build -t prometheus-storagebox-exporter .
+# Run tests / linter (same as CI)
+make test
+make lint
 
-# Run tests
-go test -v ./...
-
-# Run linter
-golangci-lint run
+# Container image (no Dockerfile): built with ko via goreleaser on release.
+# The Dockerfile is kept only for local `docker build` / docker-compose.
+KO_DOCKER_REPO=ko.local ko build . --bare --platform=linux/amd64,linux/arm64
 ```
 
 ### Project Structure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   storagebox-exporter:
     build:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crstian19/prometheus-storagebox-exporter
 
-go 1.26.2
+go 1.26.5
 
 require (
 	github.com/prometheus/client_golang v1.23.2

--- a/internal/collector/storagebox.go
+++ b/internal/collector/storagebox.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -11,6 +12,14 @@ import (
 	"github.com/crstian19/prometheus-storagebox-exporter/internal/hetzner"
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+// BuildInfo carries version metadata injected at build time, exposed as the
+// storagebox_exporter_build_info metric.
+type BuildInfo struct {
+	Version   string
+	Commit    string
+	BuildDate string
+}
 
 // StorageBoxCollector implements the prometheus.Collector interface
 type StorageBoxCollector struct {
@@ -37,6 +46,9 @@ type StorageBoxCollector struct {
 	createdTimestamp  *prometheus.Desc
 
 	// Exporter metrics
+	up             *prometheus.Desc
+	buildInfo      *prometheus.Desc
+	buildInfoData  BuildInfo
 	scrapeDuration *prometheus.Desc
 	scrapeErrors   prometheus.Counter
 	cacheHits      prometheus.Counter
@@ -51,12 +63,13 @@ type StorageBoxCollector struct {
 }
 
 // NewStorageBoxCollector creates a new StorageBoxCollector
-func NewStorageBoxCollector(client *hetzner.Client, cacheTTL time.Duration, cacheMaxSize int64, cacheCleanupInterval time.Duration) *StorageBoxCollector {
+func NewStorageBoxCollector(client *hetzner.Client, cacheTTL time.Duration, cacheMaxSize int64, cacheCleanupInterval time.Duration, buildInfo BuildInfo) *StorageBoxCollector {
 	cacheEnabled := cacheTTL > 0
 	return &StorageBoxCollector{
-		client:       client,
-		cache:        cache.NewMetricsCache(cacheTTL, cacheMaxSize, cacheCleanupInterval),
-		cacheEnabled: cacheEnabled,
+		client:        client,
+		cache:         cache.NewMetricsCache(cacheTTL, cacheMaxSize, cacheCleanupInterval),
+		cacheEnabled:  cacheEnabled,
+		buildInfoData: buildInfo,
 
 		// Core storage metrics
 		diskQuota: prometheus.NewDesc(
@@ -147,6 +160,18 @@ func NewStorageBoxCollector(client *hetzner.Client, cacheTTL time.Duration, cach
 		),
 
 		// Exporter metrics
+		up: prometheus.NewDesc(
+			"storagebox_exporter_up",
+			"Whether the last scrape of the Hetzner API succeeded (1=healthy, 0=unhealthy)",
+			nil,
+			nil,
+		),
+		buildInfo: prometheus.NewDesc(
+			"storagebox_exporter_build_info",
+			"Build information of the exporter (value always 1)",
+			[]string{"version", "revision", "goversion", "build_date"},
+			nil,
+		),
 		scrapeDuration: prometheus.NewDesc(
 			"storagebox_exporter_scrape_duration_seconds",
 			"Duration of the scrape in seconds",
@@ -201,9 +226,13 @@ func (c *StorageBoxCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.accessSSH
 	ch <- c.accessSamba
 	ch <- c.accessWebDAV
+	ch <- c.accessZFS
+	ch <- c.reachableExternal
 	ch <- c.snapshotPlan
 	ch <- c.protectionDelete
 	ch <- c.createdTimestamp
+	ch <- c.up
+	ch <- c.buildInfo
 	ch <- c.scrapeDuration
 	c.scrapeErrors.Describe(ch)
 	c.cacheHits.Describe(ch)
@@ -219,73 +248,68 @@ func (c *StorageBoxCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *StorageBoxCollector) Collect(ch chan<- prometheus.Metric) {
 	start := time.Now()
 
-	var boxes []hetzner.StorageBox
+	// build_info is static and always emitted, regardless of scrape outcome.
+	ch <- prometheus.MustNewConstMetric(
+		c.buildInfo,
+		prometheus.GaugeValue,
+		1,
+		c.buildInfoData.Version, c.buildInfoData.Commit, runtime.Version(), c.buildInfoData.BuildDate,
+	)
 
-	// Try to get data from cache first (only if cache is enabled)
-	if c.cacheEnabled {
-		if cachedData, found := c.cache.Get(); found {
-			c.cacheHits.Inc()
-			boxes = cachedData.([]hetzner.StorageBox)
-		} else {
-			// Cache miss - fetch from API
-			c.cacheMisses.Inc()
-
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			fetchedBoxes, err := c.client.ListStorageBoxes(ctx)
-			if err != nil {
-				c.handleError(err, "cache_miss")
-				c.scrapeErrors.Inc()
-				c.scrapeErrors.Collect(ch)
-				c.cacheHits.Collect(ch)
-				c.cacheMisses.Collect(ch)
-				c.authErrors.Collect(ch)
-				c.rateLimitErrors.Collect(ch)
-				c.serverErrors.Collect(ch)
-				c.clientErrors.Collect(ch)
-				c.networkErrors.Collect(ch)
-				return
-			}
-
-			boxes = fetchedBoxes
-			// Store in cache
-			c.cache.Set(boxes)
-		}
-	} else {
-		// Cache disabled - always fetch from API
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		fetchedBoxes, err := c.client.ListStorageBoxes(ctx)
-		if err != nil {
-			c.handleError(err, "direct_api_call")
-			c.scrapeErrors.Inc()
-			c.scrapeErrors.Collect(ch)
-			c.cacheHits.Collect(ch)
-			c.cacheMisses.Collect(ch)
-			c.authErrors.Collect(ch)
-			c.rateLimitErrors.Collect(ch)
-			c.serverErrors.Collect(ch)
-			c.clientErrors.Collect(ch)
-			c.networkErrors.Collect(ch)
-			return
-		}
-
-		boxes = fetchedBoxes
+	boxes, err := c.fetchBoxes()
+	if err != nil {
+		// Source unreachable/unparseable: report up=0 and omit storage box
+		// metrics (no misleading zeros or stale values), per the exporter blueprint.
+		c.emitExporterMetrics(ch, 0, time.Since(start).Seconds())
+		return
 	}
 
 	for _, box := range boxes {
 		c.collectStorageBox(ch, &box)
 	}
 
-	// Record scrape duration
-	duration := time.Since(start).Seconds()
-	ch <- prometheus.MustNewConstMetric(
-		c.scrapeDuration,
-		prometheus.GaugeValue,
-		duration,
-	)
+	c.emitExporterMetrics(ch, 1, time.Since(start).Seconds())
+}
+
+// fetchBoxes returns the storage boxes, using the cache when enabled. On error
+// it records the appropriate error counters via handleError.
+func (c *StorageBoxCollector) fetchBoxes() ([]hetzner.StorageBox, error) {
+	if c.cacheEnabled {
+		if cachedData, found := c.cache.Get(); found {
+			c.cacheHits.Inc()
+			return cachedData.([]hetzner.StorageBox), nil
+		}
+		c.cacheMisses.Inc()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		boxes, err := c.client.ListStorageBoxes(ctx)
+		if err != nil {
+			c.handleError(err, "cache_miss")
+			return nil, err
+		}
+		c.cache.Set(boxes)
+		return boxes, nil
+	}
+
+	// Cache disabled - always fetch from API
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	boxes, err := c.client.ListStorageBoxes(ctx)
+	if err != nil {
+		c.handleError(err, "direct_api_call")
+		return nil, err
+	}
+	return boxes, nil
+}
+
+// emitExporterMetrics emits the exporter-level metrics (up, scrape duration and
+// all counters) shared by both the success and failure paths.
+func (c *StorageBoxCollector) emitExporterMetrics(ch chan<- prometheus.Metric, up, duration float64) {
+	ch <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, up)
+	ch <- prometheus.MustNewConstMetric(c.scrapeDuration, prometheus.GaugeValue, duration)
 
 	c.scrapeErrors.Collect(ch)
 	c.cacheHits.Collect(ch)

--- a/internal/collector/storagebox_test.go
+++ b/internal/collector/storagebox_test.go
@@ -129,7 +129,7 @@ func TestNewStorageBoxCollector(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			collector := NewStorageBoxCollector(client, tt.cacheTTL, tt.cacheMaxSize, tt.cacheCleanupInterval)
+			collector := NewStorageBoxCollector(client, tt.cacheTTL, tt.cacheMaxSize, tt.cacheCleanupInterval, BuildInfo{})
 			if collector == nil {
 				t.Fatal("expected collector to be non-nil")
 			}
@@ -145,7 +145,7 @@ func TestNewStorageBoxCollector(t *testing.T) {
 
 func TestDescribe(t *testing.T) {
 	client := hetzner.NewClient("test-token")
-	collector := NewStorageBoxCollector(client, 0, 0, 0)
+	collector := NewStorageBoxCollector(client, 0, 0, 0, BuildInfo{})
 
 	ch := make(chan *prometheus.Desc, 100)
 	go func() {
@@ -180,7 +180,7 @@ func TestCollectSuccess(t *testing.T) {
 	server, client := setupMockServer(t, handler)
 	defer server.Close()
 
-	collector := NewStorageBoxCollector(client, 0, 0, 0)
+	collector := NewStorageBoxCollector(client, 0, 0, 0, BuildInfo{})
 
 	ch := make(chan prometheus.Metric, 100)
 	go func() {
@@ -213,7 +213,7 @@ func TestCollectWithCacheHit(t *testing.T) {
 	defer server.Close()
 
 	// Enable cache with 1 minute TTL
-	collector := NewStorageBoxCollector(client, time.Minute, 0, time.Minute)
+	collector := NewStorageBoxCollector(client, time.Minute, 0, time.Minute, BuildInfo{})
 
 	// First collection - should hit API
 	ch1 := make(chan prometheus.Metric, 100)
@@ -289,7 +289,7 @@ func TestCollectAPIError(t *testing.T) {
 			server, client := setupMockServer(t, handler)
 			defer server.Close()
 
-			collector := NewStorageBoxCollector(client, 0, 0, 0)
+			collector := NewStorageBoxCollector(client, 0, 0, 0, BuildInfo{})
 
 			ch := make(chan prometheus.Metric, 100)
 			go func() {
@@ -323,7 +323,7 @@ func TestCollectWithCacheAndAPIError(t *testing.T) {
 	defer server.Close()
 
 	// Enable cache
-	collector := NewStorageBoxCollector(client, time.Minute, 0, time.Minute)
+	collector := NewStorageBoxCollector(client, time.Minute, 0, time.Minute, BuildInfo{})
 
 	ch := make(chan prometheus.Metric, 100)
 	go func() {
@@ -389,7 +389,7 @@ func TestCollectStorageBoxMetrics(t *testing.T) {
 	server, client := setupMockServer(t, handler)
 	defer server.Close()
 
-	collector := NewStorageBoxCollector(client, 0, 0, 0)
+	collector := NewStorageBoxCollector(client, 0, 0, 0, BuildInfo{})
 
 	ch := make(chan prometheus.Metric, 100)
 	go func() {
@@ -422,7 +422,7 @@ func TestCollectEmptyStorageBoxes(t *testing.T) {
 	server, client := setupMockServer(t, handler)
 	defer server.Close()
 
-	collector := NewStorageBoxCollector(client, 0, 0, 0)
+	collector := NewStorageBoxCollector(client, 0, 0, 0, BuildInfo{})
 
 	ch := make(chan prometheus.Metric, 100)
 	go func() {
@@ -443,7 +443,7 @@ func TestCollectEmptyStorageBoxes(t *testing.T) {
 
 func TestHandleErrorAPIError(t *testing.T) {
 	client := hetzner.NewClient("test-token")
-	collector := NewStorageBoxCollector(client, 0, 0, 0)
+	collector := NewStorageBoxCollector(client, 0, 0, 0, BuildInfo{})
 
 	tests := []struct {
 		name   string
@@ -480,7 +480,7 @@ func TestHandleErrorAPIError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset collector for each test
-			collector = NewStorageBoxCollector(client, 0, 0, 0)
+			collector = NewStorageBoxCollector(client, 0, 0, 0, BuildInfo{})
 			// This should not panic
 			collector.handleError(tt.err, tt.source)
 		})
@@ -489,7 +489,7 @@ func TestHandleErrorAPIError(t *testing.T) {
 
 func TestHandleErrorNetworkError(t *testing.T) {
 	client := hetzner.NewClient("test-token")
-	collector := NewStorageBoxCollector(client, 0, 0, 0)
+	collector := NewStorageBoxCollector(client, 0, 0, 0, BuildInfo{})
 
 	// Simulate a network error (non-API error)
 	networkErr := &testNetworkError{message: "connection refused"}
@@ -516,7 +516,7 @@ func TestCollectorRegistration(t *testing.T) {
 	server, client := setupMockServer(t, handler)
 	defer server.Close()
 
-	collector := NewStorageBoxCollector(client, 0, 0, 0)
+	collector := NewStorageBoxCollector(client, 0, 0, 0, BuildInfo{})
 
 	// Create a new registry and register the collector
 	registry := prometheus.NewRegistry()
@@ -534,6 +534,98 @@ func TestCollectorRegistration(t *testing.T) {
 	if len(metrics) == 0 {
 		t.Error("expected at least some metrics after gathering")
 	}
+}
+
+// gaugeValue gathers metrics from the registry and returns the value of the
+// first sample of the named metric family, or -1 if the family is absent.
+func gaugeValue(t *testing.T, reg *prometheus.Registry, name string) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() == name {
+			return mf.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+	return -1
+}
+
+func TestCollectUpAndBuildInfo(t *testing.T) {
+	build := BuildInfo{Version: "1.2.3", Commit: "abc123", BuildDate: "2026-07-15"}
+
+	t.Run("up=1 and build_info on success", func(t *testing.T) {
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(mockStorageBoxResponse()); err != nil {
+				t.Errorf("Failed to encode mock response: %v", err)
+			}
+		}
+		server, client := setupMockServer(t, handler)
+		defer server.Close()
+
+		reg := prometheus.NewRegistry()
+		if err := reg.Register(NewStorageBoxCollector(client, 0, 0, 0, build)); err != nil {
+			t.Fatalf("failed to register collector: %v", err)
+		}
+
+		if got := gaugeValue(t, reg, "storagebox_exporter_up"); got != 1 {
+			t.Errorf("expected storagebox_exporter_up=1, got %v", got)
+		}
+
+		// build_info must always be present with value 1.
+		families, _ := reg.Gather()
+		var found bool
+		for _, mf := range families {
+			if mf.GetName() != "storagebox_exporter_build_info" {
+				continue
+			}
+			found = true
+			m := mf.GetMetric()[0]
+			if m.GetGauge().GetValue() != 1 {
+				t.Errorf("expected build_info value 1, got %v", m.GetGauge().GetValue())
+			}
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["version"] != "1.2.3" || labels["revision"] != "abc123" || labels["build_date"] != "2026-07-15" {
+				t.Errorf("unexpected build_info labels: %v", labels)
+			}
+			if labels["goversion"] == "" {
+				t.Error("expected goversion label to be set")
+			}
+		}
+		if !found {
+			t.Error("expected storagebox_exporter_build_info metric")
+		}
+	})
+
+	t.Run("up=0 and no storage box metrics on API error", func(t *testing.T) {
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		server, client := setupMockServer(t, handler)
+		defer server.Close()
+
+		reg := prometheus.NewRegistry()
+		if err := reg.Register(NewStorageBoxCollector(client, 0, 0, 0, build)); err != nil {
+			t.Fatalf("failed to register collector: %v", err)
+		}
+
+		if got := gaugeValue(t, reg, "storagebox_exporter_up"); got != 0 {
+			t.Errorf("expected storagebox_exporter_up=0, got %v", got)
+		}
+		// Storage box metrics must be omitted on failure.
+		if got := gaugeValue(t, reg, "storagebox_disk_usage_bytes"); got != -1 {
+			t.Errorf("expected no storagebox_disk_usage_bytes on failure, got %v", got)
+		}
+		// build_info must still be present even when the scrape fails.
+		if got := gaugeValue(t, reg, "storagebox_exporter_build_info"); got != 1 {
+			t.Errorf("expected build_info present on failure, got %v", got)
+		}
+	})
 }
 
 func TestCollectWithNilSnapshotPlan(t *testing.T) {
@@ -588,7 +680,7 @@ func TestCollectWithNilSnapshotPlan(t *testing.T) {
 	server, client := setupMockServer(t, handler)
 	defer server.Close()
 
-	collector := NewStorageBoxCollector(client, 0, 0, 0)
+	collector := NewStorageBoxCollector(client, 0, 0, 0, BuildInfo{})
 
 	ch := make(chan prometheus.Metric, 100)
 	go func() {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,32 @@
+# Git hooks (see the lefthook note in the vault). Setup once per clone:
+#   make setup    (runs `lefthook install`)
+# Hooks are a local courtesy for fast feedback; the real gate is CI.
+# The same checks run in .github/workflows/ci.yml — single source of truth.
+pre-commit:
+  parallel: true
+  commands:
+    gitleaks:
+      run: gitleaks protect --staged --no-banner
+      priority: 1 # fail-fast on secrets
+    fmt:
+      glob: "*.go"
+      run: gofmt -w {staged_files}
+      stage_fixed: true # re-stage what gofmt rewrote
+      priority: 2
+    lint:
+      glob: "*.go"
+      run: golangci-lint run --new-from-rev=HEAD
+      priority: 3
+
+pre-push:
+  piped: true # if tests fail, don't bother with the full lint
+  commands:
+    test:
+      run: make test
+    lint:
+      run: make lint
+
+commit-msg:
+  commands:
+    conventional:
+      run: .lefthook/commit-msg/validate-conventional.sh {1}

--- a/main.go
+++ b/main.go
@@ -52,7 +52,8 @@ func main() {
 	hetznerClient := hetzner.NewClient(cfg.HetznerToken)
 
 	// Create and register the storage box collector with cache
-	collector := collector.NewStorageBoxCollector(hetznerClient, cfg.CacheTTL, cfg.CacheMaxSize, cfg.CacheCleanupInterval)
+	buildInfo := collector.BuildInfo{Version: Version, Commit: GitCommit, BuildDate: BuildDate}
+	collector := collector.NewStorageBoxCollector(hetznerClient, cfg.CacheTTL, cfg.CacheMaxSize, cfg.CacheCleanupInterval, buildInfo)
 	prometheus.MustRegister(collector)
 
 	// Set up HTTP server

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,12 @@
+# Toolchain pinned per-repo (see the mise note in the vault).
+# Language toolchain to minor for build reproducibility; CLIs to latest.
+[tools]
+go = "1.26"
+golangci-lint = "latest"
+goreleaser = "latest"
+ko = "latest"
+lefthook = "latest"
+gitleaks = "latest"
+
+[settings]
+experimental = true


### PR DESCRIPTION
Applies a set of improvements to align the exporter with the reference blueprint.

## `feat(collector)`: up and build_info metrics
- Add `storagebox_exporter_up` (1/0). On any API failure it reports `0` and **omits** the per-storage-box metrics, so scrapes never publish misleading zeros or stale values (the README already documented this metric, but the code never emitted it).
- Add `storagebox_exporter_build_info{version,revision,goversion,build_date}`, fed from the ldflags injected into `main`.
- Fix `Describe()` (it was missing `accessZFS` and `reachableExternal`).
- Fix a double increment of `scrape_errors_total` in the error path.
- Refactor `Collect` into `fetchBoxes` + `emitExporterMetrics`; new tests for `up=1/0` and `build_info`.

## `ci`: build container images with ko via goreleaser
- Publish the image through goreleaser's `kos:` integration (Chainguard static base, multi-arch amd64/arm64, SPDX SBOM) instead of a separate docker job.
- Drop the docker buildx + QEMU job from `ci.yml`; add a ghcr login to the release job. Remove QEMU/buildx from the manual release workflow.
- The Dockerfile is kept only for local `docker build` / docker-compose.

## `chore`: dev tooling
- Pin the toolchain with `mise` and manage git hooks with `lefthook` (pre-commit: gitleaks + gofmt + incremental lint; pre-push: test + lint; commit-msg: Conventional Commits). Add `make setup`.

## Verification
- `go test -race ./...`, `go vet`, `golangci-lint run` (0 issues), `goreleaser check` all pass.
- Image comparison (same stripped binary): Dockerfile/scratch 11.7 MB vs ko/chainguard 13.1 MB; identical idle RAM/CPU.
- Ran the full docker-compose stack against the real Hetzner API: exporter `up=1` with real data, Prometheus target UP, Grafana dashboard provisioned.

> [!note] Merge with a **merge commit**, not squash, so releaser-pleaser sees the individual commit types (`feat` -> minor bump to v0.6.0).