### PR TITLE
ci: fix ko repository in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,7 +61,7 @@ kos:
     build: prometheus-storagebox-exporter
     base_image: cgr.dev/chainguard/static
     repositories:
-      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/prometheus-storagebox-exporter
+      - ghcr.io/crstian19/prometheus-storagebox-exporter
     platforms:
       - linux/amd64
       - linux/arm64


### PR DESCRIPTION
The kos `repositories` field is not template-expanded, so `{{ .Env.GITHUB_REPOSITORY_OWNER }}` reached ko verbatim and failed the v0.6.0 release. Hardcodes the owner. This is what broke the release job on the v0.6.0 tag.